### PR TITLE
Fix divide by zero error encountered when using less than 4 threads

### DIFF
--- a/src/GraphAlgorithm.cpp
+++ b/src/GraphAlgorithm.cpp
@@ -87,6 +87,7 @@ GraphAlgorithm<VertexProperty>::GraphAlgorithm(
   if (node_type == COMPUTE_NODE)
   {
     nGaloisThreads /= 4;
+    GaloisThreads = nGaloisThreads > 0 ? nGaloisThreads : 1;
     worker = new UpdateWorker<VertexProperty>(graph_path, num_compute, num_memory, node_id, node_type, net, partitioning_scheme_file);
     verticesPerThread = worker->num_vertices / nGaloisThreads > 0 ? worker->num_vertices / nGaloisThreads : 1;
 

--- a/src/GraphAlgorithm.cpp
+++ b/src/GraphAlgorithm.cpp
@@ -87,7 +87,7 @@ GraphAlgorithm<VertexProperty>::GraphAlgorithm(
   if (node_type == COMPUTE_NODE)
   {
     nGaloisThreads /= 4;
-    GaloisThreads = nGaloisThreads > 0 ? nGaloisThreads : 1;
+    nGaloisThreads = nGaloisThreads > 0 ? nGaloisThreads : 1;
     worker = new UpdateWorker<VertexProperty>(graph_path, num_compute, num_memory, node_id, node_type, net, partitioning_scheme_file);
     verticesPerThread = worker->num_vertices / nGaloisThreads > 0 ? worker->num_vertices / nGaloisThreads : 1;
 


### PR DESCRIPTION
Fixes #13 

Setting the number of threads to 1 thread in case nGaloisThreads is less than 4