### PR TITLE
Revert "Fix divide by zero error encountered when using less than 4 threads"

### DIFF
--- a/src/GraphAlgorithm.cpp
+++ b/src/GraphAlgorithm.cpp
@@ -87,7 +87,6 @@ GraphAlgorithm<VertexProperty>::GraphAlgorithm(
   if (node_type == COMPUTE_NODE)
   {
     nGaloisThreads /= 4;
-    nGaloisThreads = nGaloisThreads > 0 ? nGaloisThreads : 1;
     worker = new UpdateWorker<VertexProperty>(graph_path, num_compute, num_memory, node_id, node_type, net, partitioning_scheme_file);
     verticesPerThread = worker->num_vertices / nGaloisThreads > 0 ? worker->num_vertices / nGaloisThreads : 1;
 


### PR DESCRIPTION
Reverts Kadle11/Grudon#12

Fix is not performant and causes significant slowdown, needs revisiting